### PR TITLE
残念です。。。の表記を日本語として正しい・・・に修正

### DIFF
--- a/app/models/meal.rb
+++ b/app/models/meal.rb
@@ -51,7 +51,7 @@ class Meal < ApplicationRecord
 
   def result_message
     if red?
-      "残念です。。。あなたの食事は糖質赤字です。赤字が増えすぎるとあなたの身体の資産は減り続け、糖質破産をしてしまいます。一刻も早く収支を黒字化させてください。ちなみに#{highest_sugar_food.name}を#{highest_sugar_food.genre.lowest_sugar_food.name}に変えると
+      "残念です・・・あなたの食事は糖質赤字です。赤字が増えすぎるとあなたの身体の資産は減り続け、糖質破産をしてしまいます。一刻も早く収支を黒字化させてください。ちなみに#{highest_sugar_food.name}を#{highest_sugar_food.genre.lowest_sugar_food.name}に変えると
         #{highest_sugar_food.sugar - highest_sugar_food.genre.lowest_sugar_food.sugar}g黒字化されます。"
     else
       "おめでとうございます！！あなたの食事は糖質黒字です。安定した黒字は確実に富としてあなたの資産となります。このまま継続させましょう。ちなみに#{highest_sugar_food.name}を#{highest_sugar_food.genre.lowest_sugar_food.name}に変えると


### PR DESCRIPTION
## 概要

MVPリリース後、ユーザーのフィードバックを元に修正
糖質赤字だった食事の判定結果本文の「残念です。。。」の表記を日本語として正しい「残念です・・・」に修正