### PR TITLE
ユーザーの保存に失敗した時、トップ画面にリダイレクトされるよう修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,8 +5,7 @@ class UsersController < ApplicationController
       session[:user_id] = @user.id
       redirect_to new_meal_path, success: t('.success')
     else
-      flash.now[:danger] = t('.failure')
-      render :new
+      redirect_to root_path, danger: t('.failure')
     end
   end
 
@@ -15,8 +14,7 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       redirect_to new_meal_path, success: t('.success')
     else
-      flash.now[:danger] = t('.failure')
-      render :new
+      redirect_to root_path, danger: t('.failure')
     end
   end
 


### PR DESCRIPTION
## 概要

ユーザーの保存に失敗したとき、既に削除したフォームのページにrenderされるよう書いてしまっていたので、しっかりトップページにいくよう修正