### PR TITLE
フォントをメイリオ優先に

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -4,7 +4,7 @@
 $line-height-base: 1.65;
 
 :root{
-  --font-family-sans-serif: "Helvetica Neue", Helvetica, Arial, "游ゴシック体", "Yu Gothic", YuGothic, "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+  --font-family-sans-serif: "メイリオ", "Meiryo","MS ゴシック","Hiragino Kaku Gothic ProN","ヒラギノ角ゴ ProN W3", "sans-serif";
   --font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 


### PR DESCRIPTION
## 概要

和文で見やすいとされるメイリオを優先して設定されるよう修正